### PR TITLE
Do not generate empty macros section

### DIFF
--- a/droid-hal-prjconf.inc
+++ b/droid-hal-prjconf.inc
@@ -34,8 +34,8 @@ if [ -e $SRC_SPECIFIC/prjconf.xml ]; then
     cat $SRC_SPECIFIC/prjconf.xml >> $DEST
 fi
 
-cat $SRC_GENERIC/macros.xml >> $DEST
 if [ -e $SRC_SPECIFIC/macros.xml ]; then
+    echo "Macros:" >> $DEST
     cat $SRC_SPECIFIC/macros.xml | grep -v "^Macros:" >> $DEST
 fi
 

--- a/prjconf/macros.xml
+++ b/prjconf/macros.xml
@@ -1,3 +1,0 @@
-# Generic macros section:
-Macros:
-


### PR DESCRIPTION
If macros.xml is missing do not generate empty Macros: section to
project config.