### PR TITLE
[prjconf] Substitute droid-config-flashing with bash.

### DIFF
--- a/prjconf/prjconf.xml
+++ b/prjconf/prjconf.xml
@@ -17,3 +17,6 @@ Ignore: ofono:ofono-configs
 # All devices will eventually move to building libsparse and mkbootimg properly:
 Prefer: droid-glibc-tools
 
+# droid-hal has Requires(post): droid-config-flashing which is not really needed at build time
+# this is the only way to kludge it away
+Substitute: droid-config-flashing bash


### PR DESCRIPTION
droid-config-flashing is not needed at build time