### PR TITLE
Refactor to allow for generic macros and disable device specific mkbootimg

### DIFF
--- a/droid-hal-prjconf.inc
+++ b/droid-hal-prjconf.inc
@@ -30,7 +30,7 @@ cp -f $SRC_GENERIC/prjconf.inc $DEST
 # Instead of the xml extension the inc extension makes more sense here,
 # support both file extensions.
 for ext in inc xml ; do
-    if [ -e $SRC_SPECIFIC/prjconf.$ext ]; then
+    if [ -f $SRC_SPECIFIC/prjconf.$ext ]; then
         if grep -q "^Macros:" $SRC_SPECIFIC/prjconf.$ext; then
             echo "prjconf.$ext must not contain Macros section. Put them to macros.$ext"
             exit -1
@@ -43,7 +43,7 @@ echo "Macros:" >> $DEST
 cat $SRC_GENERIC/macros.inc >> $DEST
 
 for ext in inc xml ; do
-    if [ -e $SRC_SPECIFIC/macros.$ext ]; then
+    if [ -f $SRC_SPECIFIC/macros.$ext ]; then
         grep -v "^Macros:" $SRC_SPECIFIC/macros.$ext >> $DEST
     fi
 done

--- a/droid-hal-prjconf.inc
+++ b/droid-hal-prjconf.inc
@@ -24,20 +24,28 @@ DEST=$DESTDIR/prjconf.xml
 rm -rf %{buildroot}
 mkdir -p $DESTDIR
 
-if [ grep -q "^Macros:" $SRC_GENERIC/prjconf.xml $SRC_SPECIFIC/prjconf.xml ]; then
-    echo "prjconf.xml must not contain Macros section. Put them to macros.xml"
-    exit -1
-fi
+cp -f $SRC_GENERIC/prjconf.inc $DEST
 
-cp -f $SRC_GENERIC/prjconf.xml $DEST
-if [ -e $SRC_SPECIFIC/prjconf.xml ]; then
-    cat $SRC_SPECIFIC/prjconf.xml >> $DEST
-fi
+# The syntax inside the project configuration is not XML but RPM-like.
+# Instead of the xml extension the inc extension makes more sense here,
+# support both file extensions.
+for ext in inc xml ; do
+    if [ -e $SRC_SPECIFIC/prjconf.$ext ]; then
+        if grep -q "^Macros:" $SRC_SPECIFIC/prjconf.$ext; then
+            echo "prjconf.$ext must not contain Macros section. Put them to macros.$ext"
+            exit -1
+        fi
+        cat $SRC_SPECIFIC/prjconf.$ext >> $DEST
+    fi
+done
 
-if [ -e $SRC_SPECIFIC/macros.xml ]; then
-    echo "Macros:" >> $DEST
-    cat $SRC_SPECIFIC/macros.xml | grep -v "^Macros:" >> $DEST
-fi
+echo "Macros:" >> $DEST
+
+for ext in inc xml ; do
+    if [ -e $SRC_SPECIFIC/macros.$ext ]; then
+        grep -v "^Macros:" $SRC_SPECIFIC/macros.$ext >> $DEST
+    fi
+done
 
 %files
 %defattr(-,root,root,-)

--- a/droid-hal-prjconf.inc
+++ b/droid-hal-prjconf.inc
@@ -40,6 +40,7 @@ for ext in inc xml ; do
 done
 
 echo "Macros:" >> $DEST
+cat $SRC_GENERIC/macros.inc >> $DEST
 
 for ext in inc xml ; do
     if [ -e $SRC_SPECIFIC/macros.$ext ]; then

--- a/prjconf/macros.inc
+++ b/prjconf/macros.inc
@@ -1,0 +1,3 @@
+# Don't use device specific android-tools package
+# https://en.opensuse.org/openSUSE:Build_Service_prjconf#%25bcond
+%_without_dhd_tools 1

--- a/prjconf/prjconf.inc
+++ b/prjconf/prjconf.inc
@@ -1,3 +1,5 @@
+# -*- Mode: rpm-spec; indent-tabs-mode: nil -*-
+# vim: set filetype=spec:
 # Generic project config section
 
 Prefer: libhybris-libGLESv2


### PR DESCRIPTION
- [prjconf] Allow for configs to have RPM related inc file extension. JB#51936
  Make so that configuration fragments can have
  a more matching file extension so they can be
  edited with proper syntax highlighting or
  without false XML lints.

- [prjconf] Support generic macros in prjconf. JB#51936

- [prjconf] Don't use device specific android-tools packages. JB#51936